### PR TITLE
GW-48 add second password input, add inputs types

### DIFF
--- a/front/src/components/pages/SignIn/index.jsx
+++ b/front/src/components/pages/SignIn/index.jsx
@@ -14,7 +14,13 @@ const Index = (props) => {
                 <Box style={props.theme.h3} mt={3}>
                     Введите данные, указанные при регистрации
                 </Box>
-                <Form textFields={['E-Mail', 'Пароль']} submitButtonText="Войти" />
+                <Form
+                    textFields={[
+                        { label: 'E-Mail', type: 'email' },
+                        { label: 'Пароль', type: 'password' },
+                    ]}
+                    submitButtonText="Войти"
+                />
                 <LinkButton href="/signup" name="Регистрация" />
             </Box>
         </Container>

--- a/front/src/components/pages/SignUp/index.jsx
+++ b/front/src/components/pages/SignUp/index.jsx
@@ -19,12 +19,23 @@ const Index = observer((props) => {
                 <br />
                 прямо сейчас
             </Box>
-            <Form textFields={['E-Mail']} submitButtonText="Регистрация" onSubmit={store.incrementSignUpStep} />
+            <Form
+                textFields={[{ label: 'E-Mail', type: 'email' }]}
+                submitButtonText="Регистрация"
+                onSubmit={store.incrementSignUpStep}
+            />
             <LinkButton href="/signin" name="Войти" />
         </React.Fragment>,
         <React.Fragment key="1">
             <Box style={props.theme.h4}>Придумайте пароль, чтобы зайти в тренажер</Box>
-            <Form textFields={['Пароль']} submitButtonText="Далее" onSubmit={store.incrementSignUpStep} />
+            <Form
+                textFields={[
+                    { label: 'Введите пароль', type: 'password' },
+                    { label: 'Повторите пароль', type: 'password' },
+                ]}
+                submitButtonText="Далее"
+                onSubmit={store.incrementSignUpStep}
+            />
             <Box mt={3} style={props.theme.h5} textAlign="center">
                 Шаг 2 из 3-х
             </Box>

--- a/front/src/components/shared/ExtendedFormControl.jsx
+++ b/front/src/components/shared/ExtendedFormControl.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { FormControl, OutlinedInput, InputAdornment, InputLabel, IconButton } from '@material-ui/core';
+import { Visibility, VisibilityOff } from '@material-ui/icons';
+
+const getInputType = (type, passwordIsVisible) => {
+    if (type !== 'password') {
+        return type;
+    }
+    return passwordIsVisible ? 'text' : 'password';
+};
+
+const ExtendedFormControl = (props) => {
+    const [passwordIsVisible, setPasswordVisibility] = useState(false);
+
+    const handlePasswordVisibility = () => setPasswordVisibility(!passwordIsVisible);
+
+    const handlePasswordMouseDown = (event) => event.preventDefault();
+
+    return (
+        <FormControl variant="outlined" required={true} fullWidth={true}>
+            <InputLabel htmlFor={props.label}>{props.label}</InputLabel>
+            <OutlinedInput
+                id={props.label}
+                type={getInputType(props.type, passwordIsVisible)}
+                label={props.label}
+                endAdornment={
+                    props.type === 'password' ? (
+                        <InputAdornment position="end">
+                            <IconButton
+                                aria-label="toggle password visibility"
+                                onClick={handlePasswordVisibility}
+                                onMouseDown={handlePasswordMouseDown}
+                                edge="end"
+                            >
+                                {passwordIsVisible ? <Visibility /> : <VisibilityOff />}
+                            </IconButton>
+                        </InputAdornment>
+                    ) : null
+                }
+                labelWidth={70}
+            />
+        </FormControl>
+    );
+};
+
+export default ExtendedFormControl;

--- a/front/src/components/shared/Form.jsx
+++ b/front/src/components/shared/Form.jsx
@@ -1,20 +1,21 @@
 import React from 'react';
+import { Box } from '@material-ui/core';
+import SubmitButton from './SubmitButton';
+import ExtendedFormControl from './ExtendedFormControl';
 
-import { Box, TextField } from '@material-ui/core';
-
-import SubmitButton from 'src/components/shared/SubmitButton';
-
-const Form = (props) => (
-    <form onSubmit={props.onSubmit}>
-        {props.textFields.map((textField) => (
-            <Box key={textField} mx={2} mt={3}>
-                <TextField label={textField} required={true} variant="outlined" fullWidth={true} />
+const Form = (props) => {
+    return (
+        <form onSubmit={props.onSubmit}>
+            {props.textFields.map((textField) => (
+                <Box key={textField.label} mx={2} mt={3}>
+                    <ExtendedFormControl label={textField.label} type={textField.type} />
+                </Box>
+            ))}
+            <Box mt={3}>
+                <SubmitButton submitButtonText={props.submitButtonText} />
             </Box>
-        ))}
-        <Box mt={3}>
-            <SubmitButton submitButtonText={props.submitButtonText} />
-        </Box>
-    </form>
-);
+        </form>
+    );
+};
 
 export default Form;


### PR DESCRIPTION
Ссылка на задачу [GW-48](https://trello.com/c/AYwsmc5g/48-%D0%BF%D0%BE%D0%BB%D0%B5-%D0%BF%D0%BE%D0%B2%D1%82%D0%BE%D1%80%D0%BD%D0%BE%D0%B3%D0%BE-%D0%B2%D0%B2%D0%BE%D0%B4%D0%B0-%D0%BF%D0%B0%D1%80%D0%BE%D0%BB%D1%8F-%D0%BD%D0%B0-%D1%81%D1%82%D1%80%D0%B0%D0%BD%D0%B8%D1%86%D0%B5-%D1%80%D0%B5%D0%B3%D0%B8%D1%81%D1%82%D1%80%D0%B0%D1%86%D0%B8%D0%B8-%D0%B8%D1%81%D0%BF%D1%80%D0%B0%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5-%D1%82%D0%B8%D0%BF%D0%BE%D0%B2-%D0%BF%D0%BE%D0%BB%D0%B5%D0%B9)


### Что было сделано в задаче

Добавлено поле повторного ввода пароля на странице регистрации, добавлены типы полям "email" и "password"

### Как протестировать

Перейти по адресу http://localhost:3000/signup, пройти шаги авторизации

### Скриншоты, если были изменения в верстке

![registrationpage](https://user-images.githubusercontent.com/30486456/115303271-db2b5980-a17c-11eb-9926-8fa47c3c9dec.png)

## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
