### PR TITLE
GW-46 add "back" button to registration page

### DIFF
--- a/front/src/components/pages/SignUp/index.jsx
+++ b/front/src/components/pages/SignUp/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { observer } from 'mobx-react-lite';
-
-import { Select, MenuItem, Container, MobileStepper, Box } from '@material-ui/core';
+import { Select, MenuItem, Container, MobileStepper, Box, Button } from '@material-ui/core';
+import { KeyboardArrowLeft } from '@material-ui/icons';
 import { withTheme } from '@material-ui/core/styles';
 
 import store from 'src/store';
@@ -49,8 +49,17 @@ const Index = observer((props) => {
                     steps={tutorialSteps.length}
                     position="static"
                     activeStep={store.signUpStep}
-                    nextButton={<span />}
-                    backButton={<span />}
+                    nextButton={<Box flex={1} />}
+                    backButton={
+                        <Box flex={1}>
+                            {store.signUpStep !== 0 && (
+                                <Button size="small" onClick={store.decrementSignUpStep}>
+                                    <KeyboardArrowLeft />
+                                    Назад
+                                </Button>
+                            )}
+                        </Box>
+                    }
                 />
             </Box>
         </Container>

--- a/front/src/store/index.jsx
+++ b/front/src/store/index.jsx
@@ -7,8 +7,13 @@ class Store {
         makeObservable(this, {
             signUpStep: observable,
             incrementSignUpStep: action,
+            decrementSignUpStep: action,
         });
     }
+
+    decrementSignUpStep = () => {
+        this.signUpStep -= 1;
+    };
 
     incrementSignUpStep = () => {
         this.signUpStep += 1;


### PR DESCRIPTION
Ссылка на задачу [GW-46](https://trello.com/c/hyEge8av/46-%D0%BA%D0%BD%D0%BE%D0%BF%D0%BA%D0%B8-%D0%BD%D0%B0%D0%B2%D0%B8%D0%B3%D0%B0%D1%86%D0%B8%D0%B8-%D0%B4%D0%BB%D1%8F-%D1%81%D1%82%D1%80%D0%B0%D0%BD%D0%B8%D1%86%D1%8B-%D1%80%D0%B5%D0%B3%D0%B8%D1%81%D1%82%D1%80%D0%B0%D1%86%D0%B8%D0%B8)


### Что было сделано в задаче

Добавлена кнопка "назад" на страницу регистрации

### Как протестировать

Перейти по адресу http://localhost:3000/signup, пройти шаги авторизации

### Скриншоты, если были изменения в верстке

![backbutton](https://user-images.githubusercontent.com/30486456/115305283-83dab880-a17f-11eb-9ec3-c4b193f487d4.png)

## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
