### PR TITLE
GW-28 add progress bar to test page

### DIFF
--- a/front/src/Router.jsx
+++ b/front/src/Router.jsx
@@ -5,6 +5,7 @@ import Home from 'src/components/pages/Home';
 import SignUp from 'src/components/pages/SignUp';
 import SignIn from 'src/components/pages/SignIn';
 import CourseHomepage from 'src/components/pages/CourseHomepage';
+import Test from 'src/components/pages/Test';
 
 function Router() {
     return (
@@ -21,6 +22,9 @@ function Router() {
                 </Route>
                 <Route path="/course">
                     <CourseHomepage />
+                </Route>
+                <Route path="/test">
+                    <Test />
                 </Route>
             </Switch>
         </BrowserRouter>

--- a/front/src/components/pages/Home/index.jsx
+++ b/front/src/components/pages/Home/index.jsx
@@ -15,6 +15,9 @@ function Home() {
                 <li>
                     <Link to="/course">Курс</Link>
                 </li>
+                <li>
+                    <Link to="/test">Тест</Link>
+                </li>
             </ul>
         </React.Fragment>
     );

--- a/front/src/components/pages/Test/index.jsx
+++ b/front/src/components/pages/Test/index.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { LinearProgress } from '@material-ui/core';
+
+const Test = () => {
+    const progressPercentage = 25;
+
+    return <LinearProgress variant="determinate" value={progressPercentage} />;
+};
+
+export default Test;


### PR DESCRIPTION
Задача [GW-28](https://trello.com/c/AwyYAROO/28-%D1%81%D1%82%D1%80%D0%B0%D0%BD%D0%B8%D1%86%D0%B0-%D1%82%D0%B5%D1%81%D1%82%D0%B0-%D0%BF%D1%80%D0%BE%D0%B3%D1%80%D0%B5%D1%81%D1%81-%D0%B1%D0%B0%D1%80) в `trello.com`


### Что было сделано в задаче

Добавлен прогресс бар на страницу теста

### Как протестировать

Перейти по адресу http://localhost:3000/test, должна открыться страница теста с прогресс баром

### Скриншоты, если были изменения в верстке

![progressbar](https://user-images.githubusercontent.com/30486456/116523247-78119380-a8ef-11eb-8fb2-59e2d1815493.png)

## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
