### PR TITLE
GW-59: add swagger-ui container to view swagger doc in browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 back/target/
+back/back.iml

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ docker logs back_back_1
 ```console
 docker-compose down
 ```
+6. Go to `http://localhost:8081/index.html` in the browser to view the back API

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
     volumes:
       - gowork-back-maven-repo:/root/.m2
       - ./back:/mnt/app:Z
+      - gowork-back-swagger:/mnt/app/target/api-doc
     ports:
       - "8080:8080"
     links:
@@ -38,6 +39,18 @@ services:
       timeout: 5s
       retries: 5
       start_period: 180s  # first start may be long due to downloading dependencies
+  back-swagger-ui:
+    image: swaggerapi/swagger-ui
+    volumes:
+      - gowork-back-swagger:/gowork
+    environment:
+      - SWAGGER_JSON=/gowork/openapi.json
+    ports:
+      - "8081:8080"
+    links:
+      - back
+    depends_on:
+      - back
   front:
     build: ./front
     ports:
@@ -48,3 +61,4 @@ services:
       - back
 volumes:
   gowork-back-maven-repo:
+  gowork-back-swagger:


### PR DESCRIPTION
Задача [GW-59](https://trello.com/c/85So9hJQ/59-%D0%B4%D0%BE%D0%B1%D0%B0%D0%B2%D0%B8%D1%82%D1%8C-ui-%D0%B4%D0%BB%D1%8F-%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%B0%D1%86%D0%B8%D0%B8) в `trello.com`


### Что было сделано в задаче
Теперь поднимается контейнер со swagger-ui и можно смотреть красивую документацию апишки в браузере



### Как протестировать
Поднимаем контейнеры:
```console
docker-compose up -d
```
Заходим в браузере на `http://localhost:8081/index.html`


### Скриншоты, если были изменения в верстке



## Чеклист для проверки

- [ ] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [ ] Задача в трелло стоит в колонке review
- [ ] Этот PR открыт только для одной задачи
- [ ] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [ ] Нет лишних коммитов, типа `fix`, `tmp`
- [ ] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
