### PR TITLE
GW-57 add custom nginx configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ docker logs back_back_1
 ```console
 docker-compose down
 ```
+
+## http-requests from browser
+1. Add `/backend` prefix to location in every request.
+For example, instead `http://localhost:3000/login` use `http://localhost:3000/backend/login`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,9 @@ services:
       retries: 5
       start_period: 180s  # first start may be long due to downloading dependencies
   front:
+    environment:
+      BACK_NAME: back
+      BACK_PORT: 8080
     build: ./front
     ports:
       - "3000:80"

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /hh-gowork/
 COPY . .
 
 RUN yarn install \
- && yarn build
+    && yarn build
 
 FROM nginx
 
@@ -14,5 +14,7 @@ WORKDIR /usr/share/nginx/html/
 RUN rm -Rf ./*
 
 COPY --from=builder /hh-gowork/build/ .
+
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+
+    location / {
+        root            /usr/share/nginx/html;
+        index           index.html index.htm;
+        try_files       $uri /index.html;
+    }
+
+    location /backend/ {
+        proxy_pass      http://${BACK_NAME}:${BACK_PORT}/;
+    }
+}


### PR DESCRIPTION
Задача [GW-57](https://trello.com/c/82aTJtbs/57-%D0%BD%D0%B0%D1%81%D1%82%D1%80%D0%BE%D0%B9%D0%BA%D0%B0-nginx-%D0%BD%D0%B0-%D1%84%D1%80%D0%BE%D0%BD%D1%82%D0%B5) в `trello.com`


### Что было сделано в задаче

Добавлена конфигурация nginx, корректно обрабатывающая роутинг на фронте и добавляющая проксирование для запросов с фронта

### Как протестировать

Запустить проект в докере, перейти в браузере по адресу `http://localhost:3000/signup`, страница должна загрузиться корректно. Далее можно отправить в консоли браузера запрос на бэк. Например, такой:
`fetch("http://localhost:3000/backend/chapters/0/paragraphs", { method: "get" });`
в ответ на него должен прийти ответ с кодом 401 - это значит, что запрос дошел до сервера.
(Чтобы все вышеперечисленное сработало, докер также должен быть запущен на http://localhost).

В каждый запрос к бэкенду с фронта надо дописывать префикс /backend в location запроса. Например, вместо запроса
`http://localhost:3000/login`
следует отправить запрос
`http://localhost:3000/backend/login`

Это нужно, чтобы nginx понимал, какие запросы относятся к фронту (например, запрос http://localhost:3000/ выдаст базовую страницу приложения, т.к. в нем нет префикса /backend), а какие нужно проксировать на бэк.

## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
