### PR TITLE
GW-27 add answer to test step

### DIFF
--- a/front/src/components/pages/Test/components/TestStep.jsx
+++ b/front/src/components/pages/Test/components/TestStep.jsx
@@ -13,6 +13,16 @@ const TestStep = (props) => (
                 <Box style={props.theme.h6}>Ваш ответ:</Box>
             </Box>
         </Paper>
+        <Box
+            fontSize={9}
+            borderLeft={1}
+            borderColor={props.answer.correct ? 'primary.main' : 'error.main'}
+            mt={3}
+            pl={3}
+            py={1}
+        >
+            {props.answer.answersExplanations.explanation}
+        </Box>
     </Box>
 );
 

--- a/front/src/components/pages/Test/index.jsx
+++ b/front/src/components/pages/Test/index.jsx
@@ -20,7 +20,7 @@ const Test = (props) => {
             ],
         },
         {
-            id: 0,
+            id: 1,
             name: 'Введение',
             steps: [
                 {
@@ -31,7 +31,7 @@ const Test = (props) => {
                     },
                 },
                 {
-                    id: 0,
+                    id: 1,
                     theory: 'string',
                     question: {
                         html: '<span>Какие цели на курс вы ставите?</span>',
@@ -40,7 +40,7 @@ const Test = (props) => {
             ],
         },
         {
-            id: 0,
+            id: 2,
             name: 'Введение',
             steps: [
                 {
@@ -54,6 +54,47 @@ const Test = (props) => {
         },
     ];
 
+    const answers = [
+        [
+            {
+                correctAnswers: [0],
+                answersExplanations: {
+                    explanation:
+                        'Тут мы выводим информацию об ответе и обобщаем почему именно так, если пользователь ответил не верно',
+                },
+                correct: true,
+            },
+        ],
+        [
+            {
+                correctAnswers: [0],
+                answersExplanations: {
+                    explanation:
+                        'Тут мы выводим информацию об ответе и обобщаем почему именно так, если пользователь ответил не верно',
+                },
+                correct: true,
+            },
+            {
+                correctAnswers: [0],
+                answersExplanations: {
+                    explanation:
+                        'Тут мы выводим информацию об ответе и обобщаем почему именно так, если пользователь ответил не верно',
+                },
+                correct: false,
+            },
+        ],
+        [
+            {
+                correctAnswers: [0],
+                answersExplanations: {
+                    explanation:
+                        'Тут мы выводим информацию об ответе и обобщаем почему именно так, если пользователь ответил не верно',
+                },
+                correct: true,
+            },
+        ],
+    ];
+
     return (
         <React.Fragment>
             <LinearProgress variant="determinate" value={progressPercentage} />
@@ -64,7 +105,12 @@ const Test = (props) => {
                             {`§ ${paragraph.name}`}
                         </Box>
                         {paragraph.steps.map((step, stepIndex) => (
-                            <TestStep key={step.id} data={step} number={`${paragraphIndex + 1}.${stepIndex + 1}`} />
+                            <TestStep
+                                key={step.id}
+                                data={step}
+                                number={`${paragraphIndex + 1}.${stepIndex + 1}`}
+                                answer={answers[paragraphIndex][stepIndex]}
+                            />
                         ))}
                     </React.Fragment>
                 ))}


### PR DESCRIPTION
Задача [GW-27](https://trello.com/c/uEP8zxkZ/27-%D1%81%D1%82%D1%80%D0%B0%D0%BD%D0%B8%D1%86%D0%B0-%D1%82%D0%B5%D1%81%D1%82%D0%B0-%D0%B1%D0%BB%D0%BE%D0%BA%D0%B8-%D1%81-%D0%BF%D1%80%D0%B0%D0%B2%D0%B8%D0%BB%D1%8C%D0%BD%D1%8B%D0%BC%D0%B8-%D0%BE%D1%82%D0%B2%D0%B5%D1%82%D0%B0%D0%BC) в `trello.com`


### Что было сделано в задаче

Добавлен блок с правильным ответом для страницы тестов.

### Как протестировать

Запустить фронт проекта командой yarn start, перейти в браузере по адресу http://localhost:3000/test, на странице под каждым вопросом должны появиться блоки с ответами.

### Скриншоты, если были изменения в верстке

![answerunit](https://user-images.githubusercontent.com/30486456/117856268-d736b700-b2a4-11eb-9c69-e6ac8554aad6.png)

## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
