### PR TITLE
GW-59 add swagger-ui container to view swagger doc in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ docker logs back_back_1
 ```console
 docker-compose down
 ```
+6. Go to `http://localhost:8082` in the browser to view the back API
 
 ## http-requests from browser
 1. Add `/backend` prefix to location in every request.

--- a/back/swagger-ui/nginx.conf
+++ b/back/swagger-ui/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen            8082;
+    server_name       localhost;
+
+    location ~* \.(?:css|js|json|yml|yaml)$ {
+       proxy_pass http://${SWAGGER_UI_NAME}:${SWAGGER_UI_PORT};
+    }
+
+    location /index.html {
+      proxy_pass http://${SWAGGER_UI_NAME}:${SWAGGER_UI_PORT};                                       
+    }
+
+    location = / {
+      return 301 /index.html;
+    }
+
+    location / {
+      proxy_pass http://${BACK_NAME}:${BACK_PORT};
+    }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
     volumes:
       - gowork-back-maven-repo:/root/.m2
       - ./back:/mnt/app:Z
+      - gowork-back-swagger:/mnt/app/target/api-doc
     ports:
       - "8080:8080"
     links:
@@ -38,6 +39,35 @@ services:
       timeout: 5s
       retries: 5
       start_period: 180s  # first start may be long due to downloading dependencies
+  back-swagger-ui:
+    image: swaggerapi/swagger-ui
+    volumes:
+      - gowork-back-swagger:/gowork
+    environment:
+      - SWAGGER_JSON=/gowork/openapi.json
+    expose:
+      - "8080"
+    links:
+      - back
+    depends_on:
+      - back
+  back-swagger-ui-nginx:
+    image: nginx
+    command: ["nginx", "-g", "daemon off;"]
+    volumes:
+      - ./back/swagger-ui/nginx.conf:/etc/nginx/templates/default.conf.template
+    environment:
+      - BACK_NAME=back
+      - BACK_PORT=8080
+      - SWAGGER_UI_NAME=back-swagger-ui
+      # this is internal port in virtual network
+      - SWAGGER_UI_PORT=8080
+    ports:
+      - "8082:8082"
+    links:
+      - back-swagger-ui
+    depends_on:
+      - back-swagger-ui
   front:
     environment:
       BACK_NAME: back
@@ -51,3 +81,4 @@ services:
       - back
 volumes:
   gowork-back-maven-repo:
+  gowork-back-swagger:


### PR DESCRIPTION
Задача [GW-59](https://trello.com/c/85So9hJQ/59-%D0%B4%D0%BE%D0%B1%D0%B0%D0%B2%D0%B8%D1%82%D1%8C-ui-%D0%B4%D0%BB%D1%8F-%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%B0%D1%86%D0%B8%D0%B8) в `trello.com`


### Что было сделано в задаче
Теперь поднимается контейнер со swagger-ui и можно смотреть красивую документацию апишки в браузере




### Как протестировать
Поднимаем контейнеры:
```console
docker-compose up -d
```
Заходим в браузере на `http://localhost:8082`
Можно отправлять запросы на бэк с этой страницы (кнопка Try it out)



### Скриншоты, если были изменения в верстке



## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
