### PR TITLE
GW-50 return current user position on /content and track it

### DIFF
--- a/back/src/main/java/ru/gowork/dao/ParagraphDao.java
+++ b/back/src/main/java/ru/gowork/dao/ParagraphDao.java
@@ -35,13 +35,11 @@ public class ParagraphDao {
     }
 
     @Transactional
-    public Optional<Paragraph> getNextStep(Integer currentParagraphId, Integer currentStepId) {
+    public Optional<Paragraph> getNextStep(Integer currentStepId) {
         return sessionFactory.getCurrentSession()
                 .createQuery("SELECT DISTINCT paragraph FROM Paragraph paragraph JOIN FETCH " +
-                        "paragraph.steps step WHERE (paragraph.id = :id  OR paragraph.id = :nextId) " +
-                        "AND step.id = :stepId", Paragraph.class)
-                .setParameter("id", currentParagraphId)
-                .setParameter("nextId", currentParagraphId + 1)
+                        "paragraph.steps step WHERE " +
+                        "step.id = :stepId", Paragraph.class)
                 .setParameter("stepId", currentStepId + 1)
                 .uniqueResultOptional();
     }

--- a/back/src/main/java/ru/gowork/dao/UserDao.java
+++ b/back/src/main/java/ru/gowork/dao/UserDao.java
@@ -43,4 +43,13 @@ public class UserDao {
             .executeUpdate();
   }
 
+  @Transactional
+  public void setUserCurrentStep(String userEmail, Integer currentStepId) {
+    sessionFactory.getCurrentSession()
+            .createSQLQuery("UPDATE users SET current_user_step = :currentStepId WHERE email = :email")
+            .setParameter("email", userEmail)
+            .setParameter("currentStepId", currentStepId)
+            .executeUpdate();
+  }
+
 }

--- a/back/src/main/java/ru/gowork/dto/ChapterDto.java
+++ b/back/src/main/java/ru/gowork/dto/ChapterDto.java
@@ -7,6 +7,8 @@ public class ChapterDto {
     private Integer id;
     private String name;
     private List<ShortParagraphDto> paragraphs;
+    private Boolean isCurrent;
+    private Integer currentStep;
 
     public Integer getId() {
         return id;
@@ -27,6 +29,22 @@ public class ChapterDto {
     }
     public void setParagraphs(List<ShortParagraphDto> paragraphs) {
         this.paragraphs = paragraphs;
+    }
+
+    public Boolean getCurrent() {
+        return isCurrent;
+    }
+
+    public void setCurrent(Boolean current) {
+        isCurrent = current;
+    }
+
+    public Integer getCurrentStep() {
+        return currentStep;
+    }
+
+    public void setCurrentStep(Integer currentStep) {
+        this.currentStep = currentStep;
     }
 
     @Override

--- a/back/src/main/java/ru/gowork/entity/Step.java
+++ b/back/src/main/java/ru/gowork/entity/Step.java
@@ -73,4 +73,12 @@ public class Step {
     public Object getAnswersExplanations() {
         return answersExplanations;
     }
+
+    public Paragraph getParagraph() {
+        return paragraph;
+    }
+
+    public void setParagraph(Paragraph paragraph) {
+        this.paragraph = paragraph;
+    }
 }

--- a/back/src/main/java/ru/gowork/entity/User.java
+++ b/back/src/main/java/ru/gowork/entity/User.java
@@ -1,6 +1,5 @@
 package ru.gowork.entity;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -34,7 +33,7 @@ public class User {
   @Column(name = "session_token")
   private String sessionToken;
 
-  @ManyToOne(cascade = CascadeType.ALL)
+  @ManyToOne
   @JoinColumn(name = "current_user_step")
   private Step currentStep;
 

--- a/back/src/main/java/ru/gowork/mapper/ChapterMapper.java
+++ b/back/src/main/java/ru/gowork/mapper/ChapterMapper.java
@@ -3,13 +3,14 @@ package ru.gowork.mapper;
 import ru.gowork.dto.ChapterDto;
 import ru.gowork.dto.ShortParagraphDto;
 import ru.gowork.entity.Chapter;
+import ru.gowork.entity.Step;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class ChapterMapper {
 
-    public static ChapterDto fromEntity(Chapter chapter) {
+    public static ChapterDto fromEntity(Chapter chapter, Step currentStep) {
         ChapterDto dto = new ChapterDto();
         dto.setId(chapter.getId());
         dto.setName(chapter.getName());
@@ -17,6 +18,11 @@ public class ChapterMapper {
                 .map(ParagraphMapper::fromEntityShort)
                 .collect(Collectors.toList());
         dto.setParagraphs(paragraphs);
+
+        if (chapter.getId().equals(currentStep.getParagraph().getChapterId())) {
+            dto.setCurrent(true);
+            dto.setCurrentStep(currentStep.getId());
+        }
         return dto;
     }
 }

--- a/back/src/main/java/ru/gowork/resource/ChapterResource.java
+++ b/back/src/main/java/ru/gowork/resource/ChapterResource.java
@@ -7,7 +7,9 @@ import ru.gowork.service.ChapterService;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.SecurityContext;
 import java.util.List;
 
 @Path("/content")
@@ -22,8 +24,9 @@ public class ChapterResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public List<ChapterDto> getContent() {
-        List<ChapterDto> dtoList = service.getContent();
+    public List<ChapterDto> getContent(@Context SecurityContext securityContext) {
+        String userEmail = securityContext.getUserPrincipal().getName();
+        List<ChapterDto> dtoList = service.getContent(userEmail);
         return dtoList;
     }
 }

--- a/back/src/main/java/ru/gowork/resource/ParagraphResource.java
+++ b/back/src/main/java/ru/gowork/resource/ParagraphResource.java
@@ -5,7 +5,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.SecurityContext;
 
 import ru.gowork.service.ParagraphService;
 import ru.gowork.dto.ParagraphDto;
@@ -29,12 +31,12 @@ public class ParagraphResource {
         return paragraphs;
     }
 
-    @Path("/chapters/{chapter_id}/paragraphs/{paragraph_id}/steps/{step_id}/next")
+    @Path("/steps/{step_id}/next")
     @Produces(MediaType.APPLICATION_JSON)
     @GET
-    public ParagraphDto getNextStep(@PathParam("chapter_id") Integer chapterId,
-                                @PathParam("paragraph_id") Integer currentParagraphId,
-                                @PathParam("step_id") Integer currentStepId) {
-        return service.getNextStepInParagraph(currentParagraphId, currentStepId);
+    public ParagraphDto getNextStep(@PathParam("step_id") Integer currentStepId,
+                                @Context SecurityContext securityContext) {
+        String userEmail = securityContext.getUserPrincipal().getName();
+        return service.getNextStepInParagraph(currentStepId, userEmail);
     }
 }

--- a/back/src/main/java/ru/gowork/service/AuthService.java
+++ b/back/src/main/java/ru/gowork/service/AuthService.java
@@ -3,6 +3,7 @@ package ru.gowork.service;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import ru.gowork.entity.Step;
 import ru.gowork.entity.User;
 import ru.gowork.dao.UserDao;
 
@@ -26,6 +27,9 @@ public class AuthService {
         User user = new User();
         user.setEmail(email);
         user.setPasswordHash(passwordEncoder.encode(password));
+        Step firstStep = new Step();
+        firstStep.setId(1);
+        user.setCurrentStep(firstStep);
         userDao.registerUser(user);
     }
 

--- a/back/src/main/java/ru/gowork/service/ChapterService.java
+++ b/back/src/main/java/ru/gowork/service/ChapterService.java
@@ -1,8 +1,11 @@
 package ru.gowork.service;
 
 import ru.gowork.dao.ChapterDao;
+import ru.gowork.dao.UserDao;
 import ru.gowork.dto.ChapterDto;
 import ru.gowork.entity.Chapter;
+import ru.gowork.entity.Step;
+import ru.gowork.entity.User;
 import ru.gowork.mapper.ChapterMapper;
 
 import javax.inject.Singleton;
@@ -12,17 +15,19 @@ import java.util.stream.Collectors;
 @Singleton
 public class ChapterService {
     private final ChapterDao dao;
-    private final ChapterMapper mapper;
+    private final UserDao userDao;
 
-    public ChapterService(ChapterDao dao, ChapterMapper mapper) {
+    public ChapterService(ChapterDao dao, UserDao userDao) {
         this.dao = dao;
-        this.mapper = mapper;
+        this.userDao = userDao;
     }
 
-    public List<ChapterDto> getContent() {
+    public List<ChapterDto> getContent(String userEmail) {
         List<Chapter> chapters = dao.getContent();
+        User user = userDao.getUserByEmail(userEmail).orElseThrow(() -> new RuntimeException("user '" + userEmail + "' disappeared"));
+        Step currentStep = user.getCurrentStep();
         return chapters.stream()
-                .map(chapter -> ChapterMapper.fromEntity(chapter))
+                .map(chapter -> ChapterMapper.fromEntity(chapter, currentStep))
                 .collect(Collectors.toList());
     }
 }

--- a/back/src/test/java/ru/gowork/BaseTest.java
+++ b/back/src/test/java/ru/gowork/BaseTest.java
@@ -1,5 +1,6 @@
 package ru.gowork;
 
+import org.glassfish.jersey.server.ResourceConfig;
 import org.hibernate.SessionFactory;
 import ru.hh.nab.hibernate.transaction.TransactionalScope;
 import ru.hh.nab.starter.NabApplication;
@@ -8,6 +9,8 @@ import ru.hh.nab.testbase.NabTestBase;
 import javax.inject.Inject;
 
 public abstract class BaseTest extends NabTestBase {
+
+  protected static String FAKE_USER_EMAIL = "fake@example.com";
 
   @Inject
   protected SessionFactory sessionFactory;
@@ -19,7 +22,11 @@ public abstract class BaseTest extends NabTestBase {
   protected NabApplication getApplication() {
     return NabApplication.builder()
         .configureJersey().addAllowedPackages("ru.gowork")
-        .bindToRoot()
+        .executeOnConfig(BaseTest::registerJerseyFilters).bindToRoot()
         .build();
+  }
+
+  private static void registerJerseyFilters(ResourceConfig config) {
+    config.register(FakeAuthFeature.class);
   }
 }

--- a/back/src/test/java/ru/gowork/ChapterResourceTest.java
+++ b/back/src/test/java/ru/gowork/ChapterResourceTest.java
@@ -3,6 +3,7 @@ package ru.gowork;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.hibernate.Session;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.test.context.ContextConfiguration;
 import ru.gowork.dto.ChapterDto;
@@ -19,10 +20,40 @@ import static org.junit.Assert.assertThat;
 @ContextConfiguration(classes = TestConfig.class)
 public class ChapterResourceTest extends BaseTest {
 
+  @Before
+  public void fillDb() {
+    transactionalScope.write(() -> {
+      sessionFactory.getCurrentSession()
+              .createNativeQuery("INSERT INTO chapters (id, name) VALUES (1, 'chapter 1')")
+              .executeUpdate();
+      sessionFactory.getCurrentSession()
+              .createNativeQuery("INSERT INTO chapters (id, name) VALUES (2, 'chapter 2')")
+              .executeUpdate();
+      sessionFactory.getCurrentSession()
+              .createNativeQuery("INSERT INTO paragraphs (id, name, chapter_id) VALUES (1, 'par 1', 1)")
+              .executeUpdate();
+      sessionFactory.getCurrentSession()
+              .createNativeQuery("INSERT INTO paragraphs (id, name, chapter_id) VALUES (2, 'par 2', 1)")
+              .executeUpdate();
+      sessionFactory.getCurrentSession()
+              .createNativeQuery("INSERT INTO paragraphs (id, name, chapter_id) VALUES (3, 'par 1', 2)")
+              .executeUpdate();
+      sessionFactory.getCurrentSession()
+              .createNativeQuery("INSERT INTO steps (id, paragraph_id, theory, question, correct_answers, has_answer) VALUES " +
+                      "(1, 1, 'Some text theory 3', '{\"type\": \"free\"}', '[]', FALSE);")
+              .executeUpdate();
+      sessionFactory.getCurrentSession()
+              .createNativeQuery("INSERT INTO users (email, password_hash, current_user_step) VALUES ('" + BaseTest.FAKE_USER_EMAIL + "', '', 1);")
+              .executeUpdate();
+    });
+  }
+
   @After
   public void clearDb() {
     transactionalScope.write(() -> {
       Session session = sessionFactory.getCurrentSession();
+      session.createNativeQuery("DELETE FROM users").executeUpdate();
+      session.createNativeQuery("DELETE FROM steps").executeUpdate();
       session.createNativeQuery("DELETE FROM paragraphs").executeUpdate();
       session.createNativeQuery("DELETE FROM chapters").executeUpdate();
     });
@@ -36,23 +67,6 @@ public class ChapterResourceTest extends BaseTest {
 
   @Test
   public void checkContentData() throws JsonProcessingException {
-    transactionalScope.write(() -> {
-      sessionFactory.getCurrentSession()
-          .createNativeQuery("INSERT INTO chapters (id, name) VALUES (1, 'chapter 1')")
-          .executeUpdate();
-      sessionFactory.getCurrentSession()
-          .createNativeQuery("INSERT INTO chapters (id, name) VALUES (2, 'chapter 2')")
-          .executeUpdate();
-      sessionFactory.getCurrentSession()
-          .createNativeQuery("INSERT INTO paragraphs (id, name, chapter_id) VALUES (1, 'par 1', 1)")
-          .executeUpdate();
-      sessionFactory.getCurrentSession()
-          .createNativeQuery("INSERT INTO paragraphs (id, name, chapter_id) VALUES (2, 'par 2', 1)")
-          .executeUpdate();
-      sessionFactory.getCurrentSession()
-          .createNativeQuery("INSERT INTO paragraphs (id, name, chapter_id) VALUES (3, 'par 1', 2)")
-          .executeUpdate();
-    });
 
     ShortParagraphDto shortParagraphDto1 = new ShortParagraphDto();
     shortParagraphDto1.setId(1);
@@ -65,6 +79,8 @@ public class ChapterResourceTest extends BaseTest {
     chapterDto1.setId(1);
     chapterDto1.setName("chapter 1");
     chapterDto1.setParagraphs(List.of(shortParagraphDto1, shortParagraphDto2));
+    chapterDto1.setCurrent(true);
+    chapterDto1.setCurrentStep(1);
 
     ShortParagraphDto shortParagraphDto3 = new ShortParagraphDto();
     shortParagraphDto3.setId(3);

--- a/back/src/test/java/ru/gowork/FakeAuthFeature.java
+++ b/back/src/test/java/ru/gowork/FakeAuthFeature.java
@@ -1,0 +1,19 @@
+package ru.gowork;
+
+import ru.gowork.config.AnonymousAllowed;
+
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class FakeAuthFeature implements DynamicFeature {
+
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+        if (!resourceInfo.getResourceMethod().isAnnotationPresent(AnonymousAllowed.class)) {
+            context.register(FakeAuthFilter.class);
+        }
+    }
+}

--- a/back/src/test/java/ru/gowork/FakeAuthFilter.java
+++ b/back/src/test/java/ru/gowork/FakeAuthFilter.java
@@ -1,0 +1,44 @@
+package ru.gowork;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.SecurityContext;
+
+import java.security.Principal;
+
+
+public class FakeAuthFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+
+        requestContext.setSecurityContext(new SecurityContext() {
+            @Override
+            public Principal getUserPrincipal() {
+                return new Principal() {
+                    @Override
+                    public String getName() {
+                        return BaseTest.FAKE_USER_EMAIL;
+                    }
+                };
+            }
+
+            @Override
+            public boolean isUserInRole(String role) {
+                return role.equals("user");
+            }
+
+            @Override
+            public boolean isSecure() {
+                return requestContext.getUriInfo().getAbsolutePath().toString().startsWith("https");
+            }
+
+            @Override
+            public String getAuthenticationScheme() {
+                return "Gw-Auth-Scheme";
+            }
+        });
+    }
+}


### PR DESCRIPTION
We should return where the user is now so that frontend can
show only the specific current step. We should also update the
current position when needed.

Задача [GW-50](https://trello.com/c/eBCBrKPJ/50-%D0%BF%D1%80%D0%B8-%D0%BE%D1%82%D0%B4%D0%B0%D1%87%D0%B5-%D1%82%D0%B5%D0%BC-%D1%81%D1%82%D0%B0%D0%B2%D0%B8%D1%82%D1%8C-%D0%BC%D0%B5%D1%82%D0%BA%D1%83-current) в `trello.com`


### Что было сделано в задаче
Теперь в оглавлении возвращаются метки current: true и currentStep: <id>. Метки позволяют понять в какой главе и на каком шаге сейчас находится юзер - это позволит фронту отображать только актуальный шаг.
Метки берутся из базы, а сами значения в базе обновляются чтобы отслеживать прогресс.



### Как протестировать
1. Поднимаем контейнеры.
2. Логинимся.
3.
```
curl -X GET --cookie 'gw_session=3cfea32d-5ec8-4462-86d7-f07808f8b988' http://127.0.0.1:8080/content
```



### Скриншоты, если были изменения в верстке



## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
