### PR TITLE
GW-30 add radio group

### DIFF
--- a/front/src/components/pages/Test/components/QuestionTypes/RadioButtonGroup.jsx
+++ b/front/src/components/pages/Test/components/QuestionTypes/RadioButtonGroup.jsx
@@ -1,0 +1,72 @@
+import React, { useCallback, useState } from 'react';
+
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import Radio from '@material-ui/core/Radio';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+
+import Api from 'src/api';
+
+const RadioButtonGroup = (props) => {
+    const [radioGroupValue, setRadioGroupValue] = useState(null);
+    const [answerIsCorrect, setAnswerIsCorrect] = useState(true);
+    const [disabled, setDisabled] = useState(props.disabled);
+
+    const handleChange = useCallback((event) => {
+        setRadioGroupValue(event.target.value);
+    }, []);
+
+    const onAnswerCheck = (response) => {
+        let newAnswerIsCorrectValue = true;
+        if (radioGroupValue !== response.data[0].id.toString()) {
+            newAnswerIsCorrectValue = false;
+            setAnswerIsCorrect(newAnswerIsCorrectValue);
+        }
+
+        props.onAnswer(newAnswerIsCorrectValue, response.data[0].explanation);
+    };
+
+    const onSubmit = () => {
+        setDisabled(true);
+        Api.checkAnswer().then(onAnswerCheck).catch();
+    };
+
+    return (
+        <FormControl component="fieldset">
+            <RadioGroup aria-label="gender" name="gender1" value={radioGroupValue} onChange={handleChange}>
+                {props.data.question.answers.map((option) => (
+                    <FormControlLabel
+                        value={option.id.toString()}
+                        disabled={disabled}
+                        key={option.id}
+                        control={
+                            <Radio
+                                color={'primary'}
+                                style={
+                                    radioGroupValue === option.id.toString() && !answerIsCorrect ? { color: 'red' } : {}
+                                }
+                            />
+                        }
+                        label={option.answer}
+                    />
+                ))}
+                {!disabled && (
+                    <Box mt={2}>
+                        <Button
+                            variant={'contained'}
+                            color={'primary'}
+                            onClick={onSubmit}
+                            disabled={radioGroupValue === null}
+                        >
+                            Ответить
+                        </Button>
+                    </Box>
+                )}
+            </RadioGroup>
+        </FormControl>
+    );
+};
+
+export default RadioButtonGroup;

--- a/front/src/components/pages/Test/components/TestStep.jsx
+++ b/front/src/components/pages/Test/components/TestStep.jsx
@@ -5,6 +5,7 @@ import Paper from '@material-ui/core/Paper';
 import Button from '@material-ui/core/Button';
 import withTheme from '@material-ui/core/styles/withTheme';
 import CheckboxGroup from 'src/components/pages/Test/components/QuestionTypes/CheckboxGroup';
+import RadioButtonGroup from 'src/components/pages/Test/components/QuestionTypes/RadioButtonGroup';
 
 const TestStep = (props) => {
     const [answerIsGiven, setAnswerIsGiven] = useState(false);
@@ -33,6 +34,9 @@ const TestStep = (props) => {
                     </Box>
                     {props.data.question.type === 'checkbox' && (
                         <CheckboxGroup data={props.data} onAnswer={onAnswer} disabled={props.disabled} />
+                    )}
+                    {props.data.question.type === 'radio' && (
+                        <RadioButtonGroup data={props.data} onAnswer={onAnswer} disabled={props.disabled} />
                     )}
                 </Box>
             </Paper>


### PR DESCRIPTION
Задача [GW-30](https://trello.com/c/jY88cjOc/30-%D1%81%D1%82%D1%80%D0%B0%D0%BD%D0%B8%D1%86%D0%B0-%D1%82%D0%B5%D1%81%D1%82%D0%B0-%D0%B1%D0%BB%D0%BE%D0%BA-%D1%81-%D1%80%D0%B0%D0%B4%D0%B8%D0%BE%D0%BA%D0%BD%D0%BE%D0%BF%D0%BA%D0%BE%D0%B9) в `trello.com`


### Что было сделано в задаче

Добавлен блок ответа с радиокнопками на страницу теста 

### Как протестировать

Поменять содержимое файла C:\Users\admin\Desktop\Projects\hh\hh-gowork\back\migrations\fill-test-data.sql на следующее:

<code>

INSERT INTO students (username) VALUES ('Artur');
INSERT INTO students (username) VALUES ('BorisTheBlade');
INSERT INTO students (username) VALUES ('AnotherStudent');

INSERT INTO chapters (id, name) VALUES (1, 'chapter 1');
INSERT INTO chapters (id, name) VALUES (2, 'chapter 2');
INSERT INTO chapters (id, name) VALUES (3, 'chapter 3');

INSERT INTO paragraphs (id, name, chapter_id) VALUES (1, 'par 1', 1);
INSERT INTO paragraphs (id, name, chapter_id) VALUES (2, 'par 2', 1);
INSERT INTO paragraphs (id, name, chapter_id) VALUES (3, 'par 1', 2);
INSERT INTO paragraphs (id, name, chapter_id) VALUES (4, 'par 1', 3);

INSERT INTO steps (id, paragraph_id, theory, question, correct_answers, answers_explanations, has_answer) VALUES (1, 1, 'Some text theory', '{"type": "radio", "answers": [{"id": 1, "answer": "ans 1"}, {"id": 2, "answer": "ans 2"}, {"id": 3, "answer": "ans 3"}]}', '[1,2]', '[{"id": 1, "explanation": "explanation 1"},{"id": 2, "explanation": "explanation 2"}]', TRUE);
INSERT INTO steps (id, paragraph_id, theory, question, correct_answers, answers_explanations, has_answer) VALUES (2, 1, 'Some text theory 2', '{"type": "checkbox", "answers": [{"id": 1, "answer": "ans 1"}, {"id": 2, "answer": "ans 2"}, {"id": 3, "answer": "ans 3"}]}', '[1,2]', '[{"id": 1, "explanation": "explanation 1"},{"id": 2, "explanation": "explanation 2"}]', TRUE);
INSERT INTO steps (id, paragraph_id, theory, question, correct_answers, has_answer) VALUES (3, 1, 'Some text theory 3', '{"type": "free"}', '[]', FALSE);
INSERT INTO steps (id, paragraph_id, theory, question, correct_answers, has_answer) VALUES (4, 1, 'Some text theory 4', '{"type": "free"}', '[]', FALSE);
INSERT INTO steps (id, paragraph_id, theory, question, correct_answers, has_answer) VALUES (5, 2, 'Some text theory 5', '{"type": "free"}', '[]', FALSE);


-- this is salted hash of 'test' password
-- we should not manually set id here because the autoincrement sequence in DB does not gets updated in this case
-- and subsequents inserts through API are failed
INSERT INTO users (email, password_hash, current_user_step) VALUES ('test@example.com', '$2a$10$S2cQSOY4lWkYBNJX5hRQtulN7NygiUDDveBNTmhZcesqByDquUsrS', 1);

</code>

Затем перейти на страницу теста. Первый вопрос будет иметь вид блока с радиокнопками

### Скриншоты, если были изменения в верстке

![radio](https://user-images.githubusercontent.com/30486456/120901154-98e9a900-c652-11eb-9841-bfbab54fee91.png)

## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
