### PR TITLE
GW-35 add free text input

### DIFF
--- a/front/src/api/index.js
+++ b/front/src/api/index.js
@@ -61,8 +61,10 @@ const Api = {
 
         return response;
     },
-    async checkAnswer() {
-        const response = await axios.post(`${ApiConstants.API_BASE_URL}/answer/explanation`);
+    async getAnswerExplanation(body) {
+        const response = await axios.post(`${ApiConstants.API_BASE_URL}/answer/explanation`, JSON.stringify(body), {
+            headers: { 'Content-Type': 'text/plain' },
+        });
 
         return response;
     },

--- a/front/src/components/pages/Test/components/QuestionTypes/FreeTextInput.jsx
+++ b/front/src/components/pages/Test/components/QuestionTypes/FreeTextInput.jsx
@@ -1,0 +1,46 @@
+import React, { useState, useCallback } from 'react';
+
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import TextareaAutosize from '@material-ui/core/TextareaAutosize';
+
+import Api from 'src/api';
+
+const RadioButtonGroup = (props) => {
+    const [textAreaValue, setTextAreaValue] = useState(props.data.userAnswer || '');
+    const [disabled, setDisabled] = useState(props.answerIsComplete);
+
+    const handleChange = useCallback((event) => {
+        setTextAreaValue(event.target.value);
+    }, []);
+
+    const onSubmit = useCallback(() => {
+        setDisabled(true);
+        Api.getAnswerExplanation(textAreaValue)
+            .then(() => {
+                props.onAnswer(true, 'Спасибо за ответ!');
+            })
+            .catch();
+    }, [props, textAreaValue]);
+
+    return (
+        <React.Fragment>
+            <TextareaAutosize
+                rowsMin={3}
+                placeholder="Введите ответ текстом"
+                style={{ fontSize: '14px', width: '100%' }}
+                onChange={handleChange}
+                value={textAreaValue}
+            />
+            {!disabled && (
+                <Box mt={2}>
+                    <Button variant={'contained'} color={'primary'} onClick={onSubmit} disabled={textAreaValue === ''}>
+                        Ответить
+                    </Button>
+                </Box>
+            )}
+        </React.Fragment>
+    );
+};
+
+export default RadioButtonGroup;

--- a/front/src/components/pages/Test/components/QuestionTypes/RadioButtonGroup.jsx
+++ b/front/src/components/pages/Test/components/QuestionTypes/RadioButtonGroup.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
@@ -10,27 +10,40 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Api from 'src/api';
 
 const RadioButtonGroup = (props) => {
-    const [radioGroupValue, setRadioGroupValue] = useState(null);
+    const [radioGroupValue, setRadioGroupValue] = useState(props.data.userAnswer);
     const [answerIsCorrect, setAnswerIsCorrect] = useState(true);
-    const [disabled, setDisabled] = useState(props.disabled);
+    const [disabled, setDisabled] = useState(props.answerIsComplete);
+
+    const onAnswerCheck = useCallback(
+        (data) => {
+            let newAnswerIsCorrectValue = true;
+            if (radioGroupValue !== data[0].id.toString()) {
+                newAnswerIsCorrectValue = false;
+                setAnswerIsCorrect(newAnswerIsCorrectValue);
+            }
+
+            props.onAnswer(newAnswerIsCorrectValue, data[0].explanation);
+        },
+        [props, radioGroupValue]
+    );
+
+    useEffect(() => {
+        if (props.answerIsComplete) {
+            onAnswerCheck(props.data.answersExplanations);
+        }
+    }, [props, onAnswerCheck]);
 
     const handleChange = useCallback((event) => {
         setRadioGroupValue(event.target.value);
     }, []);
 
-    const onAnswerCheck = (response) => {
-        let newAnswerIsCorrectValue = true;
-        if (radioGroupValue !== response.data[0].id.toString()) {
-            newAnswerIsCorrectValue = false;
-            setAnswerIsCorrect(newAnswerIsCorrectValue);
-        }
-
-        props.onAnswer(newAnswerIsCorrectValue, response.data[0].explanation);
-    };
-
     const onSubmit = () => {
         setDisabled(true);
-        Api.checkAnswer().then(onAnswerCheck).catch();
+        Api.getAnswerExplanation(radioGroupValue)
+            .then((response) => {
+                onAnswerCheck(response.data);
+            })
+            .catch();
     };
 
     return (

--- a/front/src/components/pages/Test/components/TestStep.jsx
+++ b/front/src/components/pages/Test/components/TestStep.jsx
@@ -6,12 +6,13 @@ import Button from '@material-ui/core/Button';
 import withTheme from '@material-ui/core/styles/withTheme';
 import CheckboxGroup from 'src/components/pages/Test/components/QuestionTypes/CheckboxGroup';
 import RadioButtonGroup from 'src/components/pages/Test/components/QuestionTypes/RadioButtonGroup';
+import FreeTextInput from 'src/components/pages/Test/components/QuestionTypes/FreeTextInput';
 
 const TestStep = (props) => {
     const [answerIsGiven, setAnswerIsGiven] = useState(false);
     const [answerIsCorrect, setAnswerIsCorrect] = useState(true);
     const [answerExplanation, setAnswerExplanation] = useState(null);
-    const [disabled, setDisabled] = useState(false);
+    const [disabled, setDisabled] = useState(props.answerIsComplete);
 
     const onAnswer = (answerIsCorrect, explanation) => {
         setAnswerIsGiven(true);
@@ -33,10 +34,25 @@ const TestStep = (props) => {
                         Ваш ответ:
                     </Box>
                     {props.data.question.type === 'checkbox' && (
-                        <CheckboxGroup data={props.data} onAnswer={onAnswer} disabled={props.disabled} />
+                        <CheckboxGroup
+                            data={props.data}
+                            onAnswer={onAnswer}
+                            answerIsComplete={props.answerIsComplete}
+                        />
                     )}
                     {props.data.question.type === 'radio' && (
-                        <RadioButtonGroup data={props.data} onAnswer={onAnswer} disabled={props.disabled} />
+                        <RadioButtonGroup
+                            data={props.data}
+                            onAnswer={onAnswer}
+                            answerIsComplete={props.answerIsComplete}
+                        />
+                    )}
+                    {props.data.question.type === 'free' && (
+                        <FreeTextInput
+                            data={props.data}
+                            onAnswer={onAnswer}
+                            answerIsComplete={props.answerIsComplete}
+                        />
                     )}
                 </Box>
             </Paper>
@@ -50,7 +66,6 @@ const TestStep = (props) => {
                         pl={3}
                         py={1}
                     >
-                        <div>{answerIsCorrect ? 'Правильно!' : ''}</div>
                         {answerExplanation}
                     </Box>
                     {!disabled && (

--- a/front/src/components/pages/Test/index.jsx
+++ b/front/src/components/pages/Test/index.jsx
@@ -46,7 +46,7 @@ const Test = observer((props) => {
             .map((paragraph) => paragraph.steps)
             .reduce((acc, cur) => acc.concat(cur), []);
 
-        while (paragraphSteps[currentStepNumber].id !== currentStep) {
+        while (paragraphSteps[currentStepNumber] && paragraphSteps[currentStepNumber].id !== currentStep) {
             currentStepNumber += 1;
         }
 
@@ -96,7 +96,7 @@ const Test = observer((props) => {
                                 key={step.id}
                                 data={step}
                                 getNextStep={onGetNextStep}
-                                disabled={step.id !== currentStepId}
+                                answerIsComplete={step.id !== currentStepId}
                             />
                         ))}
                     </React.Fragment>


### PR DESCRIPTION
Задача [GW-35](https://trello.com/c/53mJpuZG/35-%D0%BE%D1%82%D0%B2%D0%B5%D1%82-%D1%82%D0%B5%D0%BA%D1%81%D1%82%D0%BE%D0%BC) в `trello.com`


### Что было сделано в задаче

Добавлен блок ответа со свободным вводом текста на страницу теста

### Как протестировать

Перейти на страницу теста. Третий вопрос будет иметь вид блока со свободным вводом текста

### Скриншоты, если были изменения в верстке

![freeInput](https://user-images.githubusercontent.com/30486456/120901282-4eb4f780-c653-11eb-93a2-64687e8e92d7.png)

## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
