### PR TITLE
GW-68 return user answers and explanations for completed steps

### DIFF
--- a/back/src/main/java/ru/gowork/dao/ParagraphDao.java
+++ b/back/src/main/java/ru/gowork/dao/ParagraphDao.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import ru.gowork.entity.Paragraph;
 import ru.gowork.entity.Step;
+import ru.gowork.entity.User;
 
 public class ParagraphDao {
     private final SessionFactory sessionFactory;
@@ -16,21 +17,25 @@ public class ParagraphDao {
     }
 
     @Transactional
-    public List<Paragraph> getParagraphs(Integer chapterId) {
+    public List<Paragraph> getParagraphs(Integer chapterId, User user) {
         return sessionFactory.getCurrentSession()
                 .createQuery("SELECT DISTINCT paragraph FROM Paragraph paragraph JOIN FETCH " +
-                        "paragraph.steps WHERE paragraph.chapterId = :id")
+                        "paragraph.steps step LEFT JOIN FETCH step.userAnswer ans " +
+                        "WHERE paragraph.chapterId = :id AND (ans.user = :user OR ans.user IS NULL)", Paragraph.class)
                 .setParameter("id", chapterId)
+                .setParameter("user", user)
                 .list();
     }
 
     @Transactional
-    public List<Paragraph> getParagraphsToCurrentStep(Integer chapterId, Integer currentStepId) {
+    public List<Paragraph> getParagraphsToCurrentStep(Integer chapterId, Integer currentStepId, User user) {
         return sessionFactory.getCurrentSession()
                 .createQuery("SELECT DISTINCT paragraph FROM Paragraph paragraph JOIN FETCH " +
-                        "paragraph.steps step WHERE paragraph.chapterId = :id AND step.id <= :stepId")
+                        "paragraph.steps step LEFT JOIN FETCH step.userAnswer ans WHERE paragraph.chapterId = :id " +
+                        "AND step.id <= :stepId AND (ans.user = :user OR ans.user IS NULL)", Paragraph.class)
                 .setParameter("id", chapterId)
                 .setParameter("stepId", currentStepId)
+                .setParameter("user", user)
                 .list();
     }
 

--- a/back/src/main/java/ru/gowork/dto/ExtendedParagraphDto.java
+++ b/back/src/main/java/ru/gowork/dto/ExtendedParagraphDto.java
@@ -1,0 +1,37 @@
+package ru.gowork.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExtendedParagraphDto {
+
+    private Integer id;
+
+    private String name;
+
+    private List<ExtendedStepDto> steps = new ArrayList<>();
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<ExtendedStepDto> getSteps() {
+        return steps;
+    }
+
+    public void setSteps(List<ExtendedStepDto> steps) {
+        this.steps = steps;
+    }
+}

--- a/back/src/main/java/ru/gowork/dto/ExtendedStepDto.java
+++ b/back/src/main/java/ru/gowork/dto/ExtendedStepDto.java
@@ -1,0 +1,53 @@
+package ru.gowork.dto;
+
+public class ExtendedStepDto {
+    private Integer id;
+
+    private String theory;
+
+    private Object question;
+
+    private Object userAnswer;
+
+    private Object answersExplanations;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getTheory() {
+        return theory;
+    }
+
+    public void setTheory(String theory) {
+        this.theory = theory;
+    }
+
+    public Object getQuestion() {
+        return question;
+    }
+
+    public void setQuestion(Object question) {
+        this.question = question;
+    }
+
+    public Object getUserAnswer() {
+        return userAnswer;
+    }
+
+    public void setUserAnswer(Object userAnswer) {
+        this.userAnswer = userAnswer;
+    }
+
+    public Object getAnswersExplanations() {
+        return answersExplanations;
+    }
+
+    public void setAnswersExplanations(Object answersExplanations) {
+        this.answersExplanations = answersExplanations;
+    }
+}

--- a/back/src/main/java/ru/gowork/entity/Step.java
+++ b/back/src/main/java/ru/gowork/entity/Step.java
@@ -1,16 +1,19 @@
 package ru.gowork.entity;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
+
 import org.hibernate.annotations.TypeDefs;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.Type;
-import javax.persistence.Id;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Column;
-import javax.persistence.ManyToOne;
-import javax.persistence.JoinColumn;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import java.util.List;
 
@@ -46,6 +49,9 @@ public class Step {
     @JoinColumn(name = "paragraph_id")
     private Paragraph paragraph;
 
+    @OneToOne(mappedBy = "step", fetch = FetchType.LAZY)
+    private UserAnswer userAnswer;
+
     public Integer getId() {
         return id;
     }
@@ -80,5 +86,9 @@ public class Step {
 
     public void setParagraph(Paragraph paragraph) {
         this.paragraph = paragraph;
+    }
+
+    public UserAnswer getUserAnswer() {
+        return userAnswer;
     }
 }

--- a/back/src/main/java/ru/gowork/mapper/ParagraphMapper.java
+++ b/back/src/main/java/ru/gowork/mapper/ParagraphMapper.java
@@ -1,9 +1,11 @@
 package ru.gowork.mapper;
 
-import ru.gowork.dto.ShortParagraphDto;
-import ru.gowork.entity.Paragraph;
 import ru.gowork.dto.ParagraphDto;
 import ru.gowork.dto.StepDto;
+import ru.gowork.dto.ShortParagraphDto;
+import ru.gowork.dto.ExtendedParagraphDto;
+import ru.gowork.dto.ExtendedStepDto;
+import ru.gowork.entity.Paragraph;
 
 import java.util.stream.Collectors;
 import java.util.List;
@@ -25,6 +27,17 @@ public class ParagraphMapper {
         ShortParagraphDto dto = new ShortParagraphDto();
         dto.setId(paragraph.getId());
         dto.setName(paragraph.getName());
+        return dto;
+    }
+
+    public static ExtendedParagraphDto fromEntityExtended(Paragraph paragraph) {
+        ExtendedParagraphDto dto = new ExtendedParagraphDto();
+        dto.setId(paragraph.getId());
+        dto.setName(paragraph.getName());
+        List<ExtendedStepDto> steps = paragraph.getSteps().stream()
+                .map(StepMapper::fromEntityExtended)
+                .collect(Collectors.toList());
+        dto.setSteps(steps);
         return dto;
     }
 }

--- a/back/src/main/java/ru/gowork/mapper/StepMapper.java
+++ b/back/src/main/java/ru/gowork/mapper/StepMapper.java
@@ -1,5 +1,6 @@
 package ru.gowork.mapper;
 
+import ru.gowork.dto.ExtendedStepDto;
 import ru.gowork.entity.Step;
 import ru.gowork.dto.StepDto;
 
@@ -10,6 +11,18 @@ public class StepMapper {
         dto.setId(step.getId());
         dto.setTheory(step.getTheory());
         dto.setQuestion(step.getQuestion());
+        return dto;
+    }
+
+    public static ExtendedStepDto fromEntityExtended(Step step) {
+        ExtendedStepDto dto = new ExtendedStepDto();
+        dto.setId(step.getId());
+        dto.setTheory(step.getTheory());
+        dto.setQuestion(step.getQuestion());
+        dto.setAnswersExplanations(step.getAnswersExplanations());
+        if (step.getUserAnswer() != null) {
+            dto.setUserAnswer(step.getUserAnswer().getAnswer());
+        }
         return dto;
     }
 }

--- a/back/src/main/java/ru/gowork/resource/ParagraphResource.java
+++ b/back/src/main/java/ru/gowork/resource/ParagraphResource.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
 
+import ru.gowork.dto.ExtendedParagraphDto;
 import ru.gowork.service.ParagraphService;
 import ru.gowork.dto.ParagraphDto;
 
@@ -26,8 +27,10 @@ public class ParagraphResource {
     @Path("/chapters/{chapter_id}/paragraphs")
     @Produces(MediaType.APPLICATION_JSON)
     @GET
-    public List<ParagraphDto> getChapterParagraphs(@PathParam("chapter_id") Integer id, @QueryParam("current_step") Integer currentStepId) {
-        List<ParagraphDto> paragraphs = service.getChapterParagraphs(id, currentStepId);
+    public List<ExtendedParagraphDto> getChapterParagraphs(@PathParam("chapter_id") Integer id, @QueryParam("current_step") Integer currentStepId,
+                                                   @Context SecurityContext securityContext) {
+        String userEmail = securityContext.getUserPrincipal().getName();
+        List<ExtendedParagraphDto> paragraphs = service.getChapterParagraphs(id, currentStepId, userEmail);
         return paragraphs;
     }
 

--- a/back/src/main/java/ru/gowork/service/ParagraphService.java
+++ b/back/src/main/java/ru/gowork/service/ParagraphService.java
@@ -2,6 +2,7 @@ package ru.gowork.service;
 
 import ru.gowork.dao.ParagraphDao;
 import ru.gowork.dao.UserDao;
+import ru.gowork.dto.ExtendedParagraphDto;
 import ru.gowork.entity.User;
 import ru.gowork.mapper.ParagraphMapper;
 import ru.gowork.dto.ParagraphDto;
@@ -19,15 +20,17 @@ public class ParagraphService {
         this.userDao = userDao;
     }
 
-    public List<ParagraphDto> getChapterParagraphs(Integer chapterId, Integer currentStepId) {
+    public List<ExtendedParagraphDto> getChapterParagraphs(Integer chapterId, Integer currentStepId, String userEmail) {
+        User user = userDao.getUserByEmail(userEmail).orElseThrow(() -> new RuntimeException("user '" + userEmail + "' disappeared"));
+
         List<Paragraph> paragraphs;
         if (currentStepId != null) {
-            paragraphs = dao.getParagraphsToCurrentStep(chapterId, currentStepId);
+            paragraphs = dao.getParagraphsToCurrentStep(chapterId, currentStepId, user);
         } else {
-            paragraphs = dao.getParagraphs(chapterId);
+            paragraphs = dao.getParagraphs(chapterId, user);
         }
         return paragraphs.stream()
-                .map(paragraph -> ParagraphMapper.fromEntity(paragraph))
+                .map(ParagraphMapper::fromEntityExtended)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
We should show previous answers and explanations if the user
relogins.

Задача [GW-68](https://trello.com/c/yWmgtnlA/68-%D0%B2%D0%BE%D0%B7%D0%B2%D1%80%D0%B0%D1%89%D0%B0%D1%82%D1%8C-%D0%BE%D1%82%D0%B2%D0%B5%D1%82%D1%8B-%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8F-%D0%B8-%D0%B8%D1%85-%D0%BE%D0%BF%D0%B8%D1%81%D0%B0%D0%BD%D0%B8%D1%8F-%D0%BF%D1%80%D0%B8-%D0%BE%D1%82%D0%B4%D0%B0%D1%87%D0%B5-%D0%BF%D1%80%D0%BE%D0%B9%D0%B4%D0%B5%D0%BD%D0%BD%D1%8B%D1%85-%D1%81%D1%82%D0%B5%D0%BF%D0%BE%D0%B2) в `trello.com`


### Что было сделано в задаче
Теперь в списке пройденных параграфов вовзращаются также ответы пользователя и пояснения к правильным ответам. Это позволит отображать уже пройденные шаги вместе с ответами.


### Как протестировать
Регистрируемся/логинимся.
Сохраняем ответы в БД.
```
curl -X GET --cookie "gw_session=$GW_COOKIE" http://127.0.0.1:8080/chapters/1/paragraphs?current_step=1
```


### Скриншоты, если были изменения в верстке



## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
