### PR TITLE
GW-71 Add correct_answer in step

### DIFF
--- a/back/src/main/java/ru/gowork/dto/ExtendedStepDto.java
+++ b/back/src/main/java/ru/gowork/dto/ExtendedStepDto.java
@@ -1,5 +1,7 @@
 package ru.gowork.dto;
 
+import java.util.List;
+
 public class ExtendedStepDto {
     private Integer id;
 
@@ -8,6 +10,8 @@ public class ExtendedStepDto {
     private Object question;
 
     private Object userAnswer;
+
+    private List<Integer> correctAnswers;
 
     private Object answersExplanations;
 
@@ -41,6 +45,14 @@ public class ExtendedStepDto {
 
     public void setUserAnswer(Object userAnswer) {
         this.userAnswer = userAnswer;
+    }
+
+    public List<Integer> getCorrectAnswers() {
+        return correctAnswers;
+    }
+
+    public void setCorrectAnswers(List<Integer> correctAnswers) {
+        this.correctAnswers = correctAnswers;
     }
 
     public Object getAnswersExplanations() {

--- a/back/src/main/java/ru/gowork/mapper/StepMapper.java
+++ b/back/src/main/java/ru/gowork/mapper/StepMapper.java
@@ -19,6 +19,7 @@ public class StepMapper {
         dto.setId(step.getId());
         dto.setTheory(step.getTheory());
         dto.setQuestion(step.getQuestion());
+        dto.setCorrectAnswers(step.getCorrectAnswers());
         dto.setAnswersExplanations(step.getAnswersExplanations());
         if (step.getUserAnswer() != null) {
             dto.setUserAnswer(step.getUserAnswer().getAnswer());


### PR DESCRIPTION
Задача [GW-71](https://trello.com/c/WaTqBTwM/71-%D0%B4%D0%BE%D0%B1%D0%B0%D0%B2%D0%B8%D1%82%D1%8C-correctanswers-%D0%B2-step-%D0%B2-%D1%80%D0%B5%D1%81%D1%83%D1%80%D1%81%D0%B5-chapters-chapterid-paragraphs) в `trello.com`


### Что было сделано в задаче
Было добавлено поле correctAnswers в ExtendedStepDto.
Теперь `/chapters/{chapter_id}/paragraphs`
выдаст параграф, в степах которого будут правильные ответы.


### Как протестировать

Логинимся
`curl -i -X POST http://127.0.0.1:8080/login -d 'email=test@example.com&password=test'`

Получаем cookie
( пример куки: gw_session=8164231d-1141-4647-aa1e-31e84800314d )

Запрашиваем параграф
`curl -i -X GET --cookie "gw_session=8164231d-1141-4647-aa1e-31e84800314d"  localhost:8080/chapters/1/paragraphs`


### Скриншоты, если были изменения в верстке



## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
