### PR TITLE
GW-74 add currentParagraph field to /content

### DIFF
--- a/back/src/main/java/ru/gowork/dto/ChapterDto.java
+++ b/back/src/main/java/ru/gowork/dto/ChapterDto.java
@@ -9,6 +9,7 @@ public class ChapterDto {
     private List<ShortParagraphDto> paragraphs;
     private Boolean isCurrent;
     private Integer currentStep;
+    private Integer currentParagraph;
 
     public Integer getId() {
         return id;
@@ -45,6 +46,14 @@ public class ChapterDto {
 
     public void setCurrentStep(Integer currentStep) {
         this.currentStep = currentStep;
+    }
+
+    public Integer getCurrentParagraph() {
+        return currentParagraph;
+    }
+
+    public void setCurrentParagraph(Integer currentParagraph) {
+        this.currentParagraph = currentParagraph;
     }
 
     @Override

--- a/back/src/main/java/ru/gowork/mapper/ChapterMapper.java
+++ b/back/src/main/java/ru/gowork/mapper/ChapterMapper.java
@@ -22,6 +22,7 @@ public class ChapterMapper {
         if (chapter.getId().equals(currentStep.getParagraph().getChapterId())) {
             dto.setCurrent(true);
             dto.setCurrentStep(currentStep.getId());
+            dto.setCurrentParagraph(currentStep.getParagraph().getId());
         }
         return dto;
     }

--- a/back/src/test/java/ru/gowork/ChapterResourceTest.java
+++ b/back/src/test/java/ru/gowork/ChapterResourceTest.java
@@ -81,6 +81,7 @@ public class ChapterResourceTest extends BaseTest {
     chapterDto1.setParagraphs(List.of(shortParagraphDto1, shortParagraphDto2));
     chapterDto1.setCurrent(true);
     chapterDto1.setCurrentStep(1);
+    chapterDto1.setCurrentParagraph(1);
 
     ShortParagraphDto shortParagraphDto3 = new ShortParagraphDto();
     shortParagraphDto3.setId(3);


### PR DESCRIPTION
Задача [GW-74](https://trello.com/c/5Tc7unCW/74-%D0%B4%D0%BE%D0%B1%D0%B0%D0%B2%D0%B8%D1%82%D1%8C-currentparagraph-%D0%B2-content) в `trello.com`


### Что было сделано в задаче
Добавляем поле currentParagraph в ответ ресурса /content. Это упростит отображение на фронте.


### Как протестировать
1. Логинимся
2. Смотрим тело ответа /content


### Скриншоты, если были изменения в верстке



## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
