### PR TITLE
GW-80 fix multiple answers bug

### DIFF
--- a/back/src/main/java/ru/gowork/dao/ParagraphDao.java
+++ b/back/src/main/java/ru/gowork/dao/ParagraphDao.java
@@ -20,7 +20,7 @@ public class ParagraphDao {
     public List<Paragraph> getParagraphs(Integer chapterId, User user) {
         return sessionFactory.getCurrentSession()
                 .createQuery("SELECT DISTINCT paragraph FROM Paragraph paragraph JOIN FETCH " +
-                        "paragraph.steps step LEFT JOIN FETCH step.userAnswer ans " +
+                        "paragraph.steps step LEFT JOIN FETCH step.userAnswers ans " +
                         "WHERE paragraph.chapterId = :id AND (ans.user = :user OR ans.user IS NULL)", Paragraph.class)
                 .setParameter("id", chapterId)
                 .setParameter("user", user)
@@ -31,7 +31,7 @@ public class ParagraphDao {
     public List<Paragraph> getParagraphsToCurrentStep(Integer chapterId, Integer currentStepId, User user) {
         return sessionFactory.getCurrentSession()
                 .createQuery("SELECT DISTINCT paragraph FROM Paragraph paragraph JOIN FETCH " +
-                        "paragraph.steps step LEFT JOIN FETCH step.userAnswer ans WHERE paragraph.chapterId = :id " +
+                        "paragraph.steps step LEFT JOIN FETCH step.userAnswers ans WHERE paragraph.chapterId = :id " +
                         "AND step.id <= :stepId AND (ans.user = :user OR ans.user IS NULL)", Paragraph.class)
                 .setParameter("id", chapterId)
                 .setParameter("stepId", currentStepId)

--- a/back/src/main/java/ru/gowork/entity/Step.java
+++ b/back/src/main/java/ru/gowork/entity/Step.java
@@ -8,7 +8,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import org.hibernate.annotations.TypeDefs;
@@ -16,6 +16,7 @@ import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.Type;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Table(name = "steps")
@@ -49,8 +50,8 @@ public class Step {
     @JoinColumn(name = "paragraph_id")
     private Paragraph paragraph;
 
-    @OneToOne(mappedBy = "step", fetch = FetchType.LAZY)
-    private UserAnswer userAnswer;
+    @OneToMany(mappedBy = "step", fetch = FetchType.LAZY)
+    private Set<UserAnswer> userAnswers;
 
     public Integer getId() {
         return id;
@@ -88,7 +89,7 @@ public class Step {
         this.paragraph = paragraph;
     }
 
-    public UserAnswer getUserAnswer() {
-        return userAnswer;
+    public Set<UserAnswer> getUserAnswers() {
+        return userAnswers;
     }
 }

--- a/back/src/main/java/ru/gowork/mapper/StepMapper.java
+++ b/back/src/main/java/ru/gowork/mapper/StepMapper.java
@@ -3,6 +3,7 @@ package ru.gowork.mapper;
 import ru.gowork.dto.ExtendedStepDto;
 import ru.gowork.entity.Step;
 import ru.gowork.dto.StepDto;
+import ru.gowork.entity.UserAnswer;
 
 public class StepMapper {
 
@@ -21,8 +22,8 @@ public class StepMapper {
         dto.setQuestion(step.getQuestion());
         dto.setCorrectAnswers(step.getCorrectAnswers());
         dto.setAnswersExplanations(step.getAnswersExplanations());
-        if (step.getUserAnswer() != null) {
-            dto.setUserAnswer(step.getUserAnswer().getAnswer());
+        if (step.getUserAnswers() != null && step.getUserAnswers().size() > 0) {
+            dto.setUserAnswer(step.getUserAnswers().toArray(new UserAnswer[0])[0].getAnswer());
         }
         return dto;
     }


### PR DESCRIPTION
Hibernate may fail if there are multiple user answers in the table
but the annotation says OneToOne. Change annotation to OneToMany,
user answers is now a collection and we always take the first
element. There should be only one element anyway under normal
circumstances. It turns out that it is somehow possible to save
multiple answers to the same question, but it is a separate bug.

Задача [GW-80](https://trello.com/c/o58gcYT2/80-%D0%B1%D0%B0%D0%B3-%D1%81-%D0%BD%D0%B5%D1%81%D0%BA%D0%BE%D0%BB%D1%8C%D0%BA%D0%B8%D0%BC%D0%B8-%D0%BE%D1%82%D0%B2%D0%B5%D1%82%D0%B0%D0%BC%D0%B8) в `trello.com`


### Что было сделано в задаче
See commit message. Чиним такую ошибку на проде:
500 on /login
org.hibernate.HibernateException: More than one row with the given identifier was found: 1, for class: ru.gowork.entity.UserAnswer


### Как протестировать
Вставить в БД несколько ответов и попробовать регистрации и логины.


### Скриншоты, если были изменения в верстке



## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
