### PR TITLE
[GW-83] Limit workflow and jobs run concurrency of CD

### DIFF
--- a/.github/workflows/gowork-cicd.yml
+++ b/.github/workflows/gowork-cicd.yml
@@ -48,8 +48,8 @@ jobs:
 
             cd $WORK_DIR
 
-            git clean -n
-            git clean -f
+            git clean -dn
+            git clean -df
             git reset --hard
 
             git checkout master

--- a/.github/workflows/gowork-cicd.yml
+++ b/.github/workflows/gowork-cicd.yml
@@ -1,10 +1,10 @@
 name: GoWork CI/CD
 
 on:
-  workflow_dispatch:
-
   push:
     branches: [ master ]
+
+  workflow_dispatch:
 
 jobs:
 
@@ -22,6 +22,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [ build-and-test ]
+
+    concurrency: cd-thread
 
     steps:
 
@@ -46,6 +48,8 @@ jobs:
 
             cd $WORK_DIR
 
+            git clean -n
+            git clean -f
             git reset --hard
 
             git checkout master

--- a/.github/workflows/gowork-db-migration.yml
+++ b/.github/workflows/gowork-db-migration.yml
@@ -7,6 +7,8 @@ on:
         description: 'Migration filename to run'
         required: true
 
+concurrency: cd-thread
+
 jobs:
 
   apply-migration:
@@ -43,9 +45,13 @@ jobs:
 
             docker-compose exec -T postgres psql -U hh -f "/home/migrations/${{ github.event.inputs.filename }}"
 
+            git clean -n
+            git clean -f
             git reset --hard
+
             git checkout master
             git pull
+
             if [[ ! "${{ steps.extract_branch.outputs.branch }}" == "master" ]]
             then
               git branch -D "${{ steps.extract_branch.outputs.branch }}"

--- a/.github/workflows/gowork-db-migration.yml
+++ b/.github/workflows/gowork-db-migration.yml
@@ -45,8 +45,8 @@ jobs:
 
             docker-compose exec -T postgres psql -U hh -f "/home/migrations/${{ github.event.inputs.filename }}"
 
-            git clean -n
-            git clean -f
+            git clean -dn
+            git clean -df
             git reset --hard
 
             git checkout master

--- a/.github/workflows/schedule-cleaning.yml
+++ b/.github/workflows/schedule-cleaning.yml
@@ -1,10 +1,12 @@
 name: GoWork schedule Server cleaning
 
 on:
+  schedule:
+    - cron: "* * 12,26 * *"
+
   workflow_dispatch:
 
-  schedule:
-    - cron: "0 2 12,26 * *"
+concurrency: cd-thread
 
 jobs:
 
@@ -20,4 +22,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           host: ${{ secrets.SSH_HOST }}
           port: ${{ secrets.SSH_PORT }}
-          script: docker system prune -af
+          script: |
+            docker system df --verbose
+
+            docker system prune --all --force


### PR DESCRIPTION
Задача [GW-83](https://trello.com/c/ovgRb2LH/83-%D0%BD%D0%B0%D1%81%D1%82%D1%80%D0%BE%D0%B8%D1%82%D1%8C-%D0%BF%D0%BE%D1%81%D0%BB%D0%B5%D0%B4%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8C%D0%BD%D1%8B%D0%B9-%D0%B7%D0%B0%D0%BF%D1%83%D1%81%D0%BA-workflow-github-actions) в `trello.com`


### Что было сделано в задаче

Настроен последовательный запуск Рабочих процессов [workflow] GoWork CI/CD и некоторых Заданий [job], связанных с CD 

### Как протестировать

Принять одновременно несколько ПР, и запустить установку Миграций [Migration] на удаленном сервере

## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
