### PR TITLE
GW-85 add totalSteps to /content

### DIFF
--- a/back/src/main/java/ru/gowork/dao/ChapterDao.java
+++ b/back/src/main/java/ru/gowork/dao/ChapterDao.java
@@ -20,4 +20,11 @@ public class ChapterDao {
                         "chapter.paragraphs paragraphs ORDER BY chapter.id")
                 .list();
     }
+
+    @Transactional
+    public Integer getTotalSteps() {
+        return sessionFactory.getCurrentSession()
+            .createQuery("SELECT count(*) from Step", Long.class)
+            .getSingleResult().intValue();
+    }
 }

--- a/back/src/main/java/ru/gowork/dto/ChapterDto.java
+++ b/back/src/main/java/ru/gowork/dto/ChapterDto.java
@@ -10,6 +10,7 @@ public class ChapterDto {
     private Boolean isCurrent;
     private Integer currentStep;
     private Integer currentParagraph;
+    private Integer totalSteps;
 
     public Integer getId() {
         return id;
@@ -54,6 +55,14 @@ public class ChapterDto {
 
     public void setCurrentParagraph(Integer currentParagraph) {
         this.currentParagraph = currentParagraph;
+    }
+
+    public Integer getTotalSteps() {
+        return totalSteps;
+    }
+
+    public void setTotalSteps(Integer totalSteps) {
+        this.totalSteps = totalSteps;
     }
 
     @Override

--- a/back/src/main/java/ru/gowork/mapper/ChapterMapper.java
+++ b/back/src/main/java/ru/gowork/mapper/ChapterMapper.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 
 public class ChapterMapper {
 
-    public static ChapterDto fromEntity(Chapter chapter, Step currentStep) {
+    public static ChapterDto fromEntity(Chapter chapter, Step currentStep, Integer totalSteps) {
         ChapterDto dto = new ChapterDto();
         dto.setId(chapter.getId());
         dto.setName(chapter.getName());
@@ -23,6 +23,7 @@ public class ChapterMapper {
             dto.setCurrent(true);
             dto.setCurrentStep(currentStep.getId());
             dto.setCurrentParagraph(currentStep.getParagraph().getId());
+            dto.setTotalSteps(totalSteps);
         }
         return dto;
     }

--- a/back/src/main/java/ru/gowork/service/ChapterService.java
+++ b/back/src/main/java/ru/gowork/service/ChapterService.java
@@ -24,10 +24,11 @@ public class ChapterService {
 
     public List<ChapterDto> getContent(String userEmail) {
         List<Chapter> chapters = dao.getContent();
+        Integer totalSteps = dao.getTotalSteps();
         User user = userDao.getUserByEmail(userEmail).orElseThrow(() -> new RuntimeException("user '" + userEmail + "' disappeared"));
         Step currentStep = user.getCurrentStep();
         return chapters.stream()
-                .map(chapter -> ChapterMapper.fromEntity(chapter, currentStep))
+                .map(chapter -> ChapterMapper.fromEntity(chapter, currentStep, totalSteps))
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Задача [GW-85](https://trello.com/c/7vRa7IrG/85-%D0%B4%D0%BE%D0%B1%D0%B0%D0%B2%D0%B8%D1%82%D1%8C-%D0%B2-content-%D0%BF%D0%BE%D0%BB%D0%B5-%D1%81-%D0%BC%D0%B0%D0%BA%D1%81%D0%B8%D0%BC%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%BC-%D1%87%D0%B8%D1%81%D0%BB%D0%BE%D0%BC-%D1%81%D1%82%D0%B5%D0%BF%D0%BE%D0%B2) в `trello.com`


### Что было сделано в задаче
В результат запроса к `/content` добавлено поле totalSteps с общим числом степов во всей БД.


### Как протестировать
* Залогиниться: `curl -i -X POST http://127.0.0.1:8080/login -d "email=test@example.com&password=test"`
* Получить контент: `curl --cookie "gw_session=<куки из прошлого запроса>" localhost:8080/content`
  В ответном json'е должно быть поле `totalSteps`

### Скриншоты, если были изменения в верстке



## Чеклист для проверки

- [x] Ветка называется `GW-[номер задачи из трелло]`. Для задачи https://trello.com/c/cjbG0nCi/44-test ветка будет называться `GW-44`
- [x] Задача в трелло стоит в колонке review
- [x] Этот PR открыт только для одной задачи
- [x] Все коммиты пишутся как `GW-[номер задачи из трелло] суть изменений`, например: `GW-44 add test task`
- [x] Нет лишних коммитов, типа `fix`, `tmp`
- [x] Базовая ветка установлена правильно, в PR нет чужих коммитов и мержей
